### PR TITLE
Use OIDC trusted publishing to publish to NPM (PP-3299)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,16 +5,20 @@ on:
   release:
     types: [published]
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   release:
     runs-on: ubuntu-latest
 
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install Node.js 💻
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: 22
         registry-url: https://registry.npmjs.org/
@@ -30,7 +34,14 @@ jobs:
         TZ: America/New_York
       run: npm test
 
+    - name: Upgrade npm for OIDC support 📦
+      # Upgrade npm to support OIDC trusted publishing. Earlier steps run with the
+      # npm version bundled with current Node version to maintain consistency with
+      # the development environment. Only the Publish step requires the newer version.
+      # See https://docs.npmjs.com/trusted-publishers
+      # > Note: Trusted publishing requires npm CLI version 11.5.1 or later.
+      # TODO: This can be removed once we upgrade to Node 24 or greater.
+      run: npm install -g npm@^11.5.1
+
     - name: Publish 📚
       run: npm publish --access public
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Description

- Updates the "release" GitHub Actions workflow to use the ["trusted publisher" paradigm](https://docs.npmjs.com/trusted-publishers) to publish this package to NPM.
- Updates GitHub Actions used in this workflow to current versions.

Note: This change depends on changes (already made) to [the configuration for this project on NPM](https://www.npmjs.com/package/@thepalaceproject/library-registry-admin/access). 

## Motivation and Context

NPM deprecated and has now phased out long-lived tokens for publishing via CI. Trusted publishing is now the recommended approach.

[Jira PP-3299]

## How Has This Been Tested?

This PR makes changes only to the GitHub Actions release/publication workflow. No updates are made to the actual package code.

Once this change is merged, we will need to perform a release to verify that it is working correctly.

## Checklist:

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.