### PR TITLE
Correct provenance for OIDC trusted publishing (PP-3299)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Admin Interface for The Palace Project Library Registry",
   "repository": {
     "type": "git",
-    "url": "https://github.com/thepalaceproject/library-registry-admin.git"
+    "url": "https://github.com/ThePalaceProject/library-registry-admin.git"
   },
   "main": "dist/library-registry-admin.js",
   "author": "The Palace Project",


### PR DESCRIPTION
## Description

- Correct the repo URL so that the case of the organization name matches that of the GitHub URL.

## Motivation and Context

There was a provenance mismatch in the `npm publish` step in `release.yml`. WhileThe issue seems to be that the  Here are the relevant messages from the GitHub Action log:
```
npm notice publish Provenance statement published to transparency log: https://search.sigstore.dev/?logIndex=811936003
npm error code E422
npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/@thepalaceproject%2flibrary-registry-admin - Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "git+https://github.com/thepalaceproject/library-registry-admin.git", expected to match "https://github.com/ThePalaceProject/library-registry-admin" from provenance
```

Note that, while the message seems to imply that the `.git` extension should be removed as well, we did not see a problem with the `circulation-admin` repo, where it is present.

## How Has This Been Tested?

- No mainline code changes, and tests continue to pass.
- Will test with a branch-based release once this PR is approved.

## Checklist:

- N/A - I have updated the documentation accordingly.
- [x] All new and existing tests passed.
